### PR TITLE
LANG環境変数をdocker-composeに入れ、.envファイルをdocker containerにコピーしないようにする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,5 +50,4 @@ RUN apt update && \
 
 COPY check_device_status.sh /opt/scripts/
 COPY locale/ /opt/scripts/locale/
-COPY .env /opt/scripts/
 COPY test /opt/scripts/test

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,7 @@ services:
       - LIDAR_IF
       - LIDAR_IP
       - MICRO_CONTROLLER
+      - LANG
     command:
       - "/opt/scripts/check_device_status.sh"
     volumes:
@@ -45,6 +46,7 @@ services:
       - LIDAR_IF
       - LIDAR_IP
       - MICRO_CONTROLLER
+      - LANG
     command:
       - "/opt/scripts/check_device_status.sh"
     volumes:


### PR DESCRIPTION
LANGはホストマシンのデフォルト値を使うのが良いと思います。
日本語環境の設定をしていればLANG=ja_JP.UTF-8になっているかと思います。

また.envファイルはdocker-composeの実行時にホストマシン側で読むのが良いので、スクリプトでは読み込まないようにDockerfileでcopyするところを削除しました。